### PR TITLE
Added library target for bar and foo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ set(PROJECT_NAME cpp-cmake-template)
 
 project(${PROJECT_NAME})
 
+add_subdirectory(src)
+
+# Include directories for your project
+include_directories(include)
+
 set(SOURCES
     src/bar/bar.cpp
     src/foo/foo.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Create a library target for bar
+add_library(bar
+    bar/bar.cpp
+    ../include/bar/bar.h
+)
+
+# Include directories for bar
+target_include_directories(bar PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Create a library target for foo
+add_library(foo
+    foo/foo.cpp
+    ../include/foo/foo.h
+)
+
+# Include directories for foo
+target_include_directories(foo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/bar/test_bar.cpp
+++ b/tests/bar/test_bar.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <sstream>
-#include "../../include/bar/bar.h"
+#include <bar/bar.h>
 
 TEST(TestTestTest, TestTestTest) {
     ASSERT_EQ(1,1);

--- a/tests/foo/test_foo.cpp
+++ b/tests/foo/test_foo.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "../../include/foo/foo.h"
+#include <foo/foo.h>
 
 TEST(TestTest, TestTest) {
     ASSERT_EQ(1,1);


### PR DESCRIPTION
- Instead of including bar/bar.h in tests/bar/test_bar.cpp like "../../include/bar/bar.h" can now include it as <bar/bar.h> which is prettier